### PR TITLE
Tell snapcraft onty to build for arm64 and amd64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ website: https://www.dwellir.com
 grade: devel
 confinement: strict
 
+architectures:
+  - amd64
+  - arm64
+
 description: |
   Polkadot is a multi-chain framework that enables interoperability and scalability for multiple blockchains.
   See: https://github.com/paritytech/polkadot


### PR DESCRIPTION
Seems building for arm64 and amd64 works on snapcraft.io

This PR explicitly tells only to build for those architectures.