### PR TITLE
1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ cd snap-polkadot
 snapcraft pack --use-lxd --debug --verbosity=debug # Takes some time.
 ```
 
+## Upgrading Polkadot version
+
+Simply change the version number here: https://github.com/dwellir-public/snap-polkadot/blob/main/snap/snapcraft.yaml#L58 and then of course rebuild.
+
 ## Releasing
 
 When a commit is made to the main branch a build will start in launchpad and if successful release to the edge channel.
@@ -20,7 +24,7 @@ To promote further follow the instructions in [this document](TESTING.md)
 Promoting can be done either from [this webpage](https://snapcraft.io/polkadot/publicise)
 or by running
 `snapcraft release polkadot <revision> <channel>`
-    
+
 ### Install snap
 
 `sudo snap install <snap-file> --devmode`
@@ -37,6 +41,10 @@ For available arguments see https://github.com/paritytech/polkadot-sdk
 The value set here will be passed to the Polkadot binary with a few exceptions listed below. 
 * --name defaults to the systems hostname the first time the snap is installed.
 * --base-path is always set by the snap to `$SNAP_COMMON/polkadot_base` and is not allowed to be configured.
+
+Example:
+
+    sudo snap set polkadot service-args="--name=my-westend-node --chain=westend"
 
 #### endure
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
     after: [rust-deps]
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-v1.5.0
+    source-tag: polkadot-v1.6.0
     source-depth: 1
     build-packages:
       - build-essential


### PR DESCRIPTION
1.5.0 and 1.6.0 are both tested locally.
1.5.0 is already merged to main https://github.com/dwellir-public/snap-polkadot/commit/f1bdccbfc742f09a03251efbf02efc09b953ae4c but failed the workflow: https://github.com/dwellir-public/snap-polkadot/actions/runs/7781216376/job/21215238448
So this PR is waiting for that to be solved..