### PR TITLE
Update Polkadot version from 1.9.0 to 1.10.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
     after: [rust-deps]
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-v1.9.0
+    source-tag: polkadot-v1.10.0
     source-depth: 1
     build-packages:
       - build-essential


### PR DESCRIPTION
Made changes to update the Polkadot snap version from 1.9.0 to 1.10.0


Testing Screenshots:
![polkadot-1 10-Logs](https://github.com/dwellir-public/snap-polkadot/assets/116648836/c7f0cf5a-9d77-4ee7-908c-c68e647005b0)
![polkadot-1 10](https://github.com/dwellir-public/snap-polkadot/assets/116648836/019ddd93-3071-4496-a35d-0f56b1a5435c)
