### PR TITLE
Upgrade polkadot version to 1.11.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
     after: [rust-deps]
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-v1.10.0
+    source-tag: polkadot-v1.11.0
     source-depth: 1
     build-packages:
       - build-essential


### PR DESCRIPTION
I have upgraded the polkadot version. from 1.10.0 to 1.11.0 

Screenshots:
- ![logs](https://github.com/dwellir-public/snap-polkadot/assets/116648836/0aeca4b9-9b4f-4033-a9ef-feaafd222768)

- ![snap-info](https://github.com/dwellir-public/snap-polkadot/assets/116648836/9203f746-e91b-4d70-b10a-57ac3bf49e3a)

- ![testing](https://github.com/dwellir-public/snap-polkadot/assets/116648836/32710c4c-3a12-4388-a69d-58cfd81062a0)
