### PR TITLE
Build crash issue fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
       source "$HOME/.cargo/env"
       rustup default stable
       rustup update
+      rustup install nightly
       rustup target add wasm32-unknown-unknown
       rustup component add rust-src
       rustup update nightly


### PR DESCRIPTION
On merging, the build was getting crashed. For some reason, `nightly` toolchain was not yet installed when tried to add the `rust-src` component to it. To address this issue, i needed to ensure that the `nightly` toolchain is installed.

