### PR TITLE
Update snap version and removed rust-deps part from the yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,25 +39,7 @@ description: |
   Use this when restarts should be avoided e.g. when running a validator.
 
 parts:
-
-  rust-deps:
-    plugin: nil
-    build-packages:
-     - curl
-    override-pull: |
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      source "$HOME/.cargo/env"
-      rustup default stable
-      rustup update
-      rustup install nightly
-      rustup target add wasm32-unknown-unknown
-      rustup component add rust-src
-      rustup update nightly
-      rustup target add wasm32-unknown-unknown --toolchain nightly
-      rustup component add rust-src --toolchain nightly
-
   polkadot:
-    after: [rust-deps]
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
     source-tag: polkadot-v1.11.0
@@ -74,6 +56,13 @@ parts:
     override-pull: |
       craftctl default
       craftctl set version="$(git describe --tags --abbrev=10)-$(git rev-parse --short HEAD)"
+      rustup default stable
+      rustup update
+      rustup target add wasm32-unknown-unknown
+      rustup component add rust-src
+      rustup update nightly
+      rustup target add wasm32-unknown-unknown --toolchain nightly
+      rustup component add rust-src --toolchain nightly
     rust-path:
       - polkadot/
     prime:


### PR DESCRIPTION
### Description:
Here we have updated the `Polkadot` snap version from `1.10.0` to `1.11.0`. Along with this update we have removed the `rust-deps` section from yaml file since it wasn't needed specially for the rust installation and we have moved the commands (e.g setting the default Rust `toolchain` to the stable channel) to the `polkadot` section. As we already have set up `plugin` to `rust` in `polkadot` section, which will automatically take care of everything regarding rust installation. 

### Reason:
- New version was available for the `polkadot`.
- Reason for removing the `rust-deps`: rust was not getting installed properly. During debug, the path `$HOME/.cargo/env` was not setting up when doing the source `$HOME/.cargo/env`. Also rust toolchain was not getting set up properly. 

### Testing:
- Updated Polkadot:
![Polkadot1 11 0](https://github.com/dwellir-public/snap-polkadot/assets/116648836/9e44fbd4-8751-4bb2-93ba-ce12f7ab59fa)

- Node Status:
![Check-Node-Status](https://github.com/dwellir-public/snap-polkadot/assets/116648836/38849d1b-f94e-47b7-98fd-7744f2f4a98b)

- Snap Info:
![SnapInfo](https://github.com/dwellir-public/snap-polkadot/assets/116648836/f5559966-8ce6-4454-aa71-47d8e0e99b96)

**Note**: Discussed the changes with @Maharacha. `rust-deps` was added by @jonathanudd earlier. If there's any specific reason we added `rust-deps` than it can be discussed.