### PR TITLE
Updated to 1.12

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
   polkadot:
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-v1.11.0
+    source-tag: polkadot-v1.12.0
     source-depth: 1
     build-packages:
       - build-essential


### PR DESCRIPTION
Updated the polkadot snap version to 1.12

Testing:
![image](https://github.com/dwellir-public/snap-polkadot/assets/116648836/93e1385d-d3c5-4bfc-aaba-ed8e4e640a47)
