### PR TITLE
v1.14.0 - contains a known bug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ parts:
   polkadot:
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-v1.13.0
+    source-tag: polkadot-v1.14.0
     source-depth: 1
     build-packages:
       - build-essential
@@ -59,7 +59,7 @@ parts:
     # Make the commit hash available for snap info
     override-pull: |
       craftctl default
-      craftctl set version="1.13.0-$(git rev-parse --short HEAD)"
+      craftctl set version="1.14.0-$(git rev-parse --short HEAD)"
       # craftctl set version="$(git describe --tags --abbrev=10)-$(git rev-parse --short HEAD)"
       rustup default stable
       rustup update


### PR DESCRIPTION
This upgrades to 1.14.0 which however seems to contain a bug that causes the client to crash.