### PR TITLE
Support for alternative base-path and endure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,43 @@ or from snap store
 
 #### service-args
 
-default=--base-path=$SNAP_COMMON/polkadot_base --name=<hostname>
+```sudo snap set polkadot service-args="<my service args>"```
 
 For available arguments see https://github.com/paritytech/polkadot-sdk
-The value set here will be passed to the Polkadot binary with a few exceptions listed below. 
-* --name defaults to the systems hostname the first time the snap is installed.
-* --base-path is always set by the snap to `$SNAP_COMMON/polkadot_base` and is not allowed to be configured.
 
 Example:
 
-    sudo snap set polkadot service-args="--name=my-westend-node --chain=westend"
+```
+sudo snap set polkadot service-args="--base-path=/var/snap/polkadot/common/polkadot_base \
+--name DWELLIR-NODE \
+--chain kusama \
+--prometheus-external \
+--pruning archive \
+--rpc-external \
+--rpc-port=9933 \
+--rpc-cors all \
+--rpc-methods Safe \
+--rpc-max-connections=1000"
+```
 
 #### endure
 
-default=false
+```sudo snap set polkadot endure=true|false```
 
 If true the Polkadot service will not be restarted after a snap refresh.
 Note that the Polkadot service will still be restarted as the result of changing service-args, etc.
 
 Use this when restarts should be avoided e.g. when running a validator.
+
+#### Changing base-path outside of the SNAP_COMMON directory
+Setting an alternative base-path can be done by connecting the snap removable-media interface This allows the snap to access external filsystems/dirs (see: snap interface removable-media)
+
+    sudo snap connect polkadot:removable-media
+
+Configure your startup parameters (written to /var/snap/polkadot/common/service-arguments). 
+
+    sudo snap set polkadot service-args='--base-path /mnt/polkadot/'
+
 
 ### Start the service
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,3 +73,14 @@ Note: there is a utility script called [check_node_status.py](check_node_status.
 For each of Kusama, Westend and Rococo
 1. Clean the environment as described in the [preparation section](#preparations-before-running-tests)
 1. Run [edge tests](#test-initial-installation)
+
+
+### Testing with snapstore
+
+If you need to test stuff related to snapstore you can use the following steps:
+
+1. Upload to a branch (lives for 30 days)
+   snapcraft upload <snap>
+   snapcraft release <rev> channel latest/edge/my-tests
+
+2. sudo snap install snap --channel latest/edge/my-tests

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,7 +15,7 @@ handle_service_args_config()
     validate_service_args "$service_args"
     set_service_args "$service_args"
     write_service_args_file
-    restart_polkadot
+    # restart_polkadot
 }
 
 handle_endure_config()

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. "$SNAP/utils/utils.sh"
+
+set -e
+log "Initializing default polkadot snap configuration."
+BASE_PATH="$SNAP_COMMON/polkadot_base"
+DEFAULT_SERVICE_ARGS="--base-path=$BASE_PATH --name=$(hostname)"
+
+# Set snap Defaults
+snapctl set service-args="$DEFAULT_SERVICE_ARGS"
+log "Setting default service-args: $DEFAULT_SERVICE_ARGS"
+# TODO: Find a way to restart the service despite the snapcraft.yaml endure setting.
+snapctl set endure=true
+log "Setting default endure: true"
+

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
 . "$SNAP/utils/utils.sh"
-. "$SNAP/utils/endure-utils.sh"
-. "$SNAP/utils/service-args-utils.sh"
+. "$SNAP/utils/endure-utils.sh" 
 
-# Write to service args file to apply any effects from code changes
-write_service_args_file
-
-if ! endure; then
-    log "Restarting polkadot after a refresh."
-    restart_polkadot
+if [ $(get_endure) = "true" ]; then
+    log "Endure is enabled, not restarting service."
+    exit 0
+else
+    log "Endure is disabled, restarting service."
+    snapctl restart polkadot
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,7 @@ website: https://www.dwellir.com
 grade: stable
 confinement: strict
 
+
 platforms:
   amd64:
 
@@ -56,7 +57,6 @@ parts:
       - libclang-dev 
       - pkg-config
       - protobuf-compiler
-    # Make the commit hash available for snap info
     override-pull: |
       rustup install stable
       rustup default stable
@@ -94,13 +94,22 @@ apps:
     daemon: simple
     install-mode: disable
     refresh-mode: endure
-    restart-condition: never
+    restart-condition: on-failure
     plugs:
       - network
       - network-bind
+      - removable-media
+      - system-observe
+      - hardware-observe
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
 
   polkadot-cli:
     command: bin/polkadot
+    plugs:
+      - network
+      - home
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8

--- a/tests/test-helpers.bash
+++ b/tests/test-helpers.bash
@@ -37,5 +37,3 @@ check_polkadot_service_running() {
         return 1
     fi
 }
-
-

--- a/tests/test_edge.sh
+++ b/tests/test_edge.sh
@@ -22,4 +22,3 @@ sleep 20
 # Check node status using the Python script
 echo "Running node status tests..."
 python3 check_node_status.py
-

--- a/tests/test_shellscripts.sh
+++ b/tests/test_shellscripts.sh
@@ -1,0 +1,238 @@
+#!/bin/sh
+
+# Setup mock environment for testing outside of snap
+setup_mock_snap_environment() {
+    # Set default values if not already set (for testing outside snap)
+    if [ -z "$SNAP" ]; then
+        SNAP="${SNAP:-$(pwd)}"
+        export SNAP
+    fi
+    
+    if [ -z "$SNAP_COMMON" ]; then
+        SNAP_COMMON="${SNAP_COMMON:-/tmp/snap-polkadot-test}"
+        export SNAP_COMMON
+        # Create the directory if it doesn't exist
+        mkdir -p "$SNAP_COMMON"
+    fi
+    
+    if [ -z "$SNAP_DATA" ]; then
+        SNAP_DATA="${SNAP_DATA:-/tmp/snap-polkadot-data-test}"
+        export SNAP_DATA
+        mkdir -p "$SNAP_DATA"
+    fi
+    
+    # Always create mock snapctl for testing to avoid permission issues
+    # Create a temporary mock snapctl script
+    MOCK_SNAPCTL_DIR="/tmp/mock-snapctl-$$"
+    mkdir -p "$MOCK_SNAPCTL_DIR"
+    
+    cat > "$MOCK_SNAPCTL_DIR/snapctl" << 'EOF'
+#!/bin/sh
+# Mock snapctl for testing
+
+MOCK_CONFIG_FILE="/tmp/mock-snap-config-$$"
+
+case "$1" in
+    "get")
+        key="$2"
+        if [ -f "$MOCK_CONFIG_FILE" ]; then
+            # Look for exact key match, handle both key=value and key formats
+            value=$(grep "^$key=" "$MOCK_CONFIG_FILE" 2>/dev/null | head -1 | cut -d'=' -f2-)
+            if [ -n "$value" ]; then
+                echo "$value"
+            fi
+        fi
+        ;;
+    "set")
+        key_value="$2"
+        # Remove any existing entry for this key
+        key=$(echo "$key_value" | cut -d'=' -f1)
+        if [ -f "$MOCK_CONFIG_FILE" ]; then
+            grep -v "^$key=" "$MOCK_CONFIG_FILE" > "$MOCK_CONFIG_FILE.tmp" 2>/dev/null || true
+            mv "$MOCK_CONFIG_FILE.tmp" "$MOCK_CONFIG_FILE" 2>/dev/null || true
+        fi
+        # Add the new key=value pair
+        echo "$key_value" >> "$MOCK_CONFIG_FILE"
+        ;;
+    "unset")
+        key="$2"
+        if [ -f "$MOCK_CONFIG_FILE" ]; then
+            grep -v "^$key=" "$MOCK_CONFIG_FILE" > "$MOCK_CONFIG_FILE.tmp" 2>/dev/null || true
+            mv "$MOCK_CONFIG_FILE.tmp" "$MOCK_CONFIG_FILE" 2>/dev/null || true
+        fi
+        ;;
+    *)
+        echo "Mock snapctl: unsupported command $1" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$MOCK_SNAPCTL_DIR/snapctl"
+    
+    # Prepend to PATH to ensure our mock takes precedence
+    export PATH="$MOCK_SNAPCTL_DIR:$PATH"
+    
+    # Set a cleanup trap
+    trap 'rm -rf "$MOCK_SNAPCTL_DIR" "/tmp/mock-snap-config-$$" 2>/dev/null' EXIT
+    
+    echo "Mock snap environment setup:"
+    echo "  SNAP=$SNAP"
+    echo "  SNAP_COMMON=$SNAP_COMMON"
+    echo "  SNAP_DATA=$SNAP_DATA"
+    echo "  snapctl: $(command -v snapctl)"
+    
+    # Verify our mock is being used
+    if [ "$(command -v snapctl)" = "$MOCK_SNAPCTL_DIR/snapctl" ]; then
+        echo "  Mock snapctl is active"
+    else
+        echo "  Warning: Real snapctl may still be in use"
+    fi
+}
+
+# Test function for validate_service_args
+test_validate_service_args() {
+    echo "Testing validate_service_args function..."
+    
+    # Setup mock environment first
+    setup_mock_snap_environment
+    
+    . $SNAP/utils/service-args-utils.sh
+
+    local test_count=0
+    local passed_count=0
+    
+    # Helper function to run a test case
+    run_test_case() {
+        local description="$1"
+        local args="$2"
+        local expected_exit_code="$3"
+        local test_name="$4"
+        
+        test_count=$((test_count + 1))
+        echo "  Test $test_count: $description"
+        
+        # Capture current service args to restore later
+        local original_args="$(get_service_args)"
+        
+        # Run validate_service_args in a subshell to capture exit code
+        (validate_service_args $args) >/dev/null 2>&1
+        local actual_exit_code=$?
+        
+        if [ "$actual_exit_code" -eq "$expected_exit_code" ]; then
+            echo "    PASSED: Expected exit code $expected_exit_code, got $actual_exit_code"
+            passed_count=$((passed_count + 1))
+        else
+            echo "    FAILED: Expected exit code $expected_exit_code, got $actual_exit_code"
+        fi
+        
+        # Restore original service args
+        set_service_args "$original_args"
+    }
+    
+    # Test 1: Valid base-path with equals format (allowed path)
+    run_test_case "Valid base-path with equals format" \
+                  "--base-path=$SNAP_COMMON/polkadot_base/data" \
+                  0 \
+                  "valid_base_path_equals"
+    
+    # Test 2: Valid base-path with space format (allowed path)
+    run_test_case "Valid base-path with space format" \
+                  "--base-path $SNAP_COMMON/polkadot_base/subdir" \
+                  0 \
+                  "valid_base_path_space"
+    
+    # Test 3: Valid base-path pointing to /mnt
+    run_test_case "Valid base-path pointing to /mnt" \
+                  "--base-path=/mnt/external-drive" \
+                  0 \
+                  "valid_mnt_path"
+    
+    # Test 4: Valid base-path pointing to /media
+    run_test_case "Valid base-path pointing to /media" \
+                  "--base-path=/media/usb-drive" \
+                  0 \
+                  "valid_media_path"
+    
+    # Test 5: Valid base-path pointing to /run/media
+    run_test_case "Valid base-path pointing to /run/media" \
+                  "--base-path=/run/media/user/drive" \
+                  0 \
+                  "valid_run_media_path"
+    
+    # Test 6: Invalid base-path (not in allowed paths)
+    run_test_case "Invalid base-path (not allowed)" \
+                  "--base-path=/home/user/data" \
+                  1 \
+                  "invalid_base_path"
+    
+    # Test 7: Invalid base-path pointing to root
+    run_test_case "Invalid base-path pointing to root" \
+                  "--base-path=/" \
+                  1 \
+                  "invalid_root_path"
+    
+    # Test 8: Invalid base-path pointing to /tmp
+    run_test_case "Invalid base-path pointing to /tmp" \
+                  "--base-path=/tmp/polkadot" \
+                  1 \
+                  "invalid_tmp_path"
+    
+    # Test 9: Missing path after --base-path flag
+    run_test_case "Missing path after --base-path flag" \
+                  "--base-path" \
+                  1 \
+                  "missing_base_path"
+    
+    # Test 10: Multiple arguments with valid base-path
+    run_test_case "Multiple arguments with valid base-path" \
+                  "--name=test-node --base-path=$SNAP_COMMON/polkadot_base --port=30333" \
+                  0 \
+                  "multiple_args_valid"
+    
+    # Test 11: Multiple arguments with invalid base-path
+    run_test_case "Multiple arguments with invalid base-path" \
+                  "--name=test-node --base-path=/invalid/path --port=30333" \
+                  1 \
+                  "multiple_args_invalid"
+    
+    # Test 12: No base-path argument (should pass)
+    run_test_case "No base-path argument" \
+                  "--name=test-node --port=30333" \
+                  0 \
+                  "no_base_path"
+    
+    # Test 13: Empty arguments (should pass)
+    run_test_case "Empty arguments" \
+                  "" \
+                  0 \
+                  "empty_args"
+    
+    # Test 14: Base-path exactly matching allowed path (not subdirectory)
+    run_test_case "Base-path exactly matching allowed path" \
+                  "--base-path=$SNAP_COMMON/polkadot_base" \
+                  0 \
+                  "exact_allowed_path"
+    
+    # Test 15: Multiple base-path arguments (last one invalid)
+    run_test_case "Multiple base-path arguments (last invalid)" \
+                  "--base-path=$SNAP_COMMON/polkadot_base --base-path=/invalid/path" \
+                  1 \
+                  "multiple_base_paths_invalid"
+    
+    # Print test summary
+    echo ""
+    echo "Test Summary:"
+    echo "  Total tests: $test_count"
+    echo "  Passed: $passed_count"
+    echo "  Failed: $((test_count - passed_count))"
+    
+    if [ "$passed_count" -eq "$test_count" ]; then
+        echo "  All tests passed!"
+        return 0
+    else
+        echo "  Some tests failed."
+        return 1
+    fi
+}
+
+test_validate_service_args

--- a/utils/service-args-utils.sh
+++ b/utils/service-args-utils.sh
@@ -4,11 +4,12 @@
 
 BASE_PATH="$SNAP_COMMON/polkadot_base"
 SERVICE_ARGS_FILE="$SNAP_COMMON/service-arguments"
+DEFAULT_SERVICE_ARGS="--base-path=$BASE_PATH --name=$(hostname)"
 
 write_service_args_file()
 {
-    service_args="--base-path=$BASE_PATH $(get_service_args)"
-    log "Writing \"$service_args\" to $SERVICE_ARGS_FILE"
+    service_args="$(get_service_args)"
+    log "Writing snap config \"$service_args\" to file: $SERVICE_ARGS_FILE"
     echo "$service_args" > "$SERVICE_ARGS_FILE"
 }
 
@@ -22,9 +23,8 @@ get_service_args()
 {
     service_args="$(snapctl get service-args)"
     if [ -z "$service_args" ]; then
-        log "Setting default service args"
-        service_args="--name=$(hostname)"
-        # Don't use set_service_args() since it will not work when using snap unset
+        log "No service args found. Setting default service args: $DEFAULT_SERVICE_ARGS"
+        service_args="$DEFAULT_SERVICE_ARGS"
         snapctl set service-args="$service_args"
     fi
     echo "$service_args"
@@ -45,16 +45,63 @@ service_args_has_changed()
 	[ "$(get_service_args)" != "$(get_previous_service_args)" ]
 }
 
+#
+# Description: Checks that the service-args handles --base-path=<path>
+#              or --base-path <path>. It only allows those paths
+#              accepted by removable-media interface or the default
+#              snap directory $SNAP_COMMON/polkadot_base.
+#
+# Argument(s): A single string containing the service-args argument.
 validate_service_args()
 {
-    case "$1" in 
-        *base-path*)
-            log_message="base-path is not allowed to pass as a service argument restoring to last used service-args. This path is alywas used instead ${BASE_PATH}."
-            log "$log_message"
-            # Echo will be visible for a user if the configure hook fails when calling e.g. snap set SNAP_NAME service-args
-            echo "$log_message"
-            set_service_args "$(get_previous_service_args)"
-            exit 1
-            ;;
+    log "Validating service-args argument: $@"
+
+    # These paths are allowed.
+    allowed_removable_media_paths="/mnt /media /run/media $SNAP_COMMON/polkadot_base"
+
+    is_allowed_path() {
+        local path="$1"
+        for allowed_path in $allowed_removable_media_paths; do
+            case "$path" in
+                "$allowed_path"/* | "$allowed_path")
+                    log "base-path $path is allowed."
+                    return 0
+                    ;;
+            esac
+        done
+        log "base-path $path is NOT allowed. Use any of these: $allowed_removable_media_paths (Hint: sudo snap connect polkadot:removable-media)"
+        echo "base-path $path is NOT allowed. Use any of these: $allowed_removable_media_paths (Hint: sudo snap connect polkadot:removable-media)"
+        return 1
+    }
+
+    # Split arguments into words
+    set -- $@
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --base-path=*)
+                base_path="${1#--base-path=}"
+                ;;
+            --base-path)
+                shift
+                if [ -z "$1" ]; then
+                    log "No path specified for --base-path. No change was made to service-args."
+                    set_service_args "$(get_previous_service_args)"
+                    exit 1
+                fi
+                base_path="$1"
         esac
+
+        if [ -n "$base_path" ]; then
+            if ! is_allowed_path "$base_path"; then
+                set_service_args "$(get_previous_service_args)"
+                log "base-path $base_path is not allowed. Only snap default or those allowed by removable-media is allowed. No change was made to service-args."
+                exit 1
+            fi
+            # Reset to avoid false positives in next loop iteration
+            base_path=""
+        fi
+
+        shift
+    done
 }


### PR DESCRIPTION
This adds the features:

endure=false -> Trigger restart when set.

Allows now also base-path to be set in service-args variable