### PR TITLE
Release polkadot-stable2606-1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
     plugin: rust
     rust-channel: "1.88.0"
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-stable2606
+    source-tag: polkadot-stable2606-1
     source-depth: 1
     build-packages:
       - build-essential
@@ -68,7 +68,7 @@ parts:
       rustup target add wasm32v1-none --toolchain 1.88.0
       rustup target add wasm32v1-none --toolchain 1.88.0-x86_64-unknown-linux-gnu
       craftctl default
-      craftctl set version="polkadot-stable2606-$(git rev-parse --short HEAD)"
+      craftctl set version="polkadot-stable2606-1-$(git rev-parse --short HEAD)"
     rust-path:
       - polkadot/
     prime:


### PR DESCRIPTION
## Summary

- update the Polkadot SDK source tag to `polkadot-stable2606-1`
- update the generated snap version prefix to `polkadot-stable2606-1`

## Validation

- parsed `snap/snapcraft.yaml` successfully
- `git diff --check`
- verified upstream tag `polkadot-stable2606-1` at `8ae9775dc43c0d8cdd0f6d87700596e14278b1e1`

## Tracking

- NOD-4522